### PR TITLE
Mention explicitly that which = "min" is the default

### DIFF
--- a/R/availableCores.R
+++ b/R/availableCores.R
@@ -23,7 +23,7 @@
 #' settings are available.
 #'
 #' @param which A character specifying which settings to return.
-#' If `"min"`, the minimum value is returned.
+#' If `"min"` (the default), the minimum value is returned.
 #' If `"max"`, the maximum value is returned (be careful!)
 #' If `"all"`, all values are returned.
 #'


### PR DESCRIPTION
I think it's always better to explicitly write what is the default. In this case, I wasn't sure and had to run some tests + read the source to be sure.

Unless your convention is that the first option is always the default (as in `match.arg()`)?

Please let me know if you'd like me to run `devtools::document()`. Also feel free to close this PR if you think of a better way to clarify this.