### PR TITLE
Update parallelly_disable_parallel_setup_if_needed.R

### DIFF
--- a/R/parallelly_disable_parallel_setup_if_needed.R
+++ b/R/parallelly_disable_parallel_setup_if_needed.R
@@ -20,9 +20,9 @@ parallelly_disable_parallel_setup_if_needed <- function() {
   ## Can we Nothing to do for 'parallel', i.e. its internal option 'setup_strategy'
 
   ## We only need to disable 'parallel' setup for certain R versions
+  rev <- as.integer(R.version[["svn rev"]])
   if (rver == "4.1.0") {
     if (R.version[["status"]] == "Patched") {
-      rev <- as.integer(R.version[["svn rev"]])
       if (length(rev) == 1L && is.finite(rev) && rev >= 80532) {
         return()
       }


### PR DESCRIPTION
This fixes https://github.com/HenrikBengtsson/parallelly/issues/60 - all I did was move the definition of the `rev` variable out of the if statement so that it is defined when in the 4.2.0 elseif branch as well.