### PR TITLE
Adding isNodeAlive.SOCK0node

### DIFF
--- a/R/isNodeAlive.R
+++ b/R/isNodeAlive.R
@@ -42,6 +42,11 @@ isNodeAlive <- function(x, ...) UseMethod("isNodeAlive")
 isNodeAlive.default <- function(x, ...) NA
 
 #' @export
+isNodeAlive.SOCK0node <- function(x, ...) {
+  isConnectionValid(x$con)
+}  
+
+#' @export
 isNodeAlive.RichSOCKnode <- function(x, timeout = 0.0, ...) {
   debug <- isTRUE(getOption("parallelly.debug"))
   if (debug) {


### PR DESCRIPTION
Adds a method for forknodes/SOCK0nodes.

Currently, isNodeAlive for forked nodes returns NA, which is forkin' useless.  This adds a check for whether or not the connection is active.

```
> ccc <- makeForkCluster(2)
> isNodeAlive.SOCK0node <- function (x, ...) isConnectionValid(x$con)
> isNodeAlive(ccc)
[1] TRUE TRUE
> stopCluster(ccc)
> isNodeAlive(ccc)
[1] FALSE FALSE
> 
```

Seems to do what I need it to do.