### PR TITLE
Add HTCondor support to availableCores()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # Version (development version)
 
- * ...
+ * `availableCores()` gained support for CPU resources provisioned by
+   HTCondor jobs.
 
 
 # Version 1.48.0 [2026-06-29]

--- a/R/availableCores.R
+++ b/R/availableCores.R
@@ -128,6 +128,14 @@
 #'    used by the Bioconductor (>= 3.16) build and check system. If set to
 #'    true, then a maximum of 4 cores is considered.
 #'
+#'  \item `"HTCondor"` -
+#'    Query CPU resources provisioned by the HTCondor scheduler.
+#'    The number of cores is read from \env{CpusProvisioned} in the job
+#'    ClassAd given by \env{_CONDOR_JOB_AD}, or from \env{Cpus} in the
+#'    machine ClassAd given by \env{_CONDOR_MACHINE_AD}.  If neither
+#'    attribute is available, then \env{OMP_NUM_THREADS} is used when
+#'    \env{BATCH_SYSTEM} identifies an HTCondor job.
+#'
 #'  \item `"LSF"` - 
 #'    Query Platform Load Sharing Facility (LSF)/OpenLava environment variable
 #'    \env{LSB_DJOB_NUMPROC}.
@@ -293,7 +301,7 @@
 #'
 #' @importFrom parallel detectCores
 #' @export
-availableCores <- function(constraints = NULL, methods = getOption2("parallelly.availableCores.methods", c("system", "/proc/self/status", "cgroups.cpuset", "cgroups.cpuquota", "cgroups2.cpuset.cpus", "cgroups2.cpuset.cpus.effective", "cgroups2.cpu.max", "nproc", "mc.cores", "BiocParallel", "_R_CHECK_LIMIT_CORES_", "Bioconductor", "LSF", "PJM", "PBS", "SGE", "Slurm", "fallback", "custom")), na.rm = TRUE, logical = getOption2("parallelly.availableCores.logical", TRUE), default = c(current = 1L), which = c("min", "max", "all"), fraction = getOption2("parallelly.availableCores.fraction", 1.0), omit = getOption2("parallelly.availableCores.omit", 0L), max = getOption2("parallelly.availableCores.max", Inf)) {
+availableCores <- function(constraints = NULL, methods = getOption2("parallelly.availableCores.methods", c("system", "/proc/self/status", "cgroups.cpuset", "cgroups.cpuquota", "cgroups2.cpuset.cpus", "cgroups2.cpuset.cpus.effective", "cgroups2.cpu.max", "nproc", "mc.cores", "BiocParallel", "_R_CHECK_LIMIT_CORES_", "Bioconductor", "HTCondor", "LSF", "PJM", "PBS", "SGE", "Slurm", "fallback", "custom")), na.rm = TRUE, logical = getOption2("parallelly.availableCores.logical", TRUE), default = c(current = 1L), which = c("min", "max", "all"), fraction = getOption2("parallelly.availableCores.fraction", 1.0), omit = getOption2("parallelly.availableCores.omit", 0L), max = getOption2("parallelly.availableCores.max", Inf)) {
   stop_if_not(
     is.null(constraints) || is.character(constraints), !anyNA(constraints)
   )
@@ -329,7 +337,9 @@ availableCores <- function(constraints = NULL, methods = getOption2("parallelly.
   names(ncores) <- methods
   for (kk in seq_along(methods)) {
     method <- methods[kk]
-    if (method == "Slurm") {
+    if (method == "HTCondor") {
+      n <- availableCoresHTCondor()
+    } else if (method == "Slurm") {
       ## Number of cores assigned by Slurm
       n <- availableCoresSlurm()
     } else if (method == "PBS") {
@@ -688,6 +698,48 @@ getopt_int <- function(name, mode = "integer") {
 # --------------------------------------------------------------------------
 # High-Performance Compute (HPC) Schedulers
 # --------------------------------------------------------------------------
+read_htcondor_classad_int <- function(pathname, attribute) {
+  if (is.na(pathname) || !file_test("-f", pathname)) return(NA_integer_)
+
+  pattern <- sprintf(
+    "^[[:space:]]*%s[[:space:]]*=[[:space:]]*([[:digit:]]+)[[:space:]]*$",
+    attribute
+  )
+  lines <- readLines(pathname, warn = FALSE)
+  lines <- grep(pattern, lines, value = TRUE, ignore.case = TRUE)
+  if (length(lines) != 1L) return(NA_integer_)
+
+  value <- sub(pattern, "\\1", lines, ignore.case = TRUE)
+  suppressWarnings(as.integer(value))
+}
+
+
+## Number of cores provisioned by HTCondor
+availableCoresHTCondor <- local({
+  n <- NULL
+  function() {
+    if (!is.null(n)) return(n)
+
+    job_ad <- trim(getEnvVar2("_CONDOR_JOB_AD", default = NA_character_))
+    n <<- read_htcondor_classad_int(job_ad, "CpusProvisioned")
+    if (!is.na(n)) return(n)
+
+    machine_ad <- trim(
+      getEnvVar2("_CONDOR_MACHINE_AD", default = NA_character_)
+    )
+    n <<- read_htcondor_classad_int(machine_ad, "Cpus")
+    if (!is.na(n)) return(n)
+
+    batch_system <- trim(getEnvVar2("BATCH_SYSTEM", default = NA_character_))
+    if (identical(tolower(batch_system), "htcondor")) {
+      n <<- getenv_int("OMP_NUM_THREADS")
+    }
+
+    n
+  }
+})
+
+
 ## Number of slots assigned by LSF
 availableCoresLSF <- local({
   n <- NULL

--- a/R/options.R
+++ b/R/options.R
@@ -14,7 +14,7 @@
 #' \describe{
 #'  \item{`parallelly.availableCores.logical`:}{(logical) The default value of argument `logical` as used by `availableCores()`, `availableWorkers()`, and `availableCores()` for querying `parallel::detectCores(logical = logical)`.  The default is `TRUE` just like it is for [parallel::detectCores()].}
 #'
-#'  \item{`parallelly.availableCores.methods`:}{(character vector) Default lookup methods for [availableCores()]. (Default: `c("system", "/proc/self/status", "cgroups.cpuset", "cgroups.cpuquota", "cgroups2.cpuset.cpus", "cgroups2.cpuset.cpus.effective", "cgroups2.cpu.max", "nproc", "mc.cores", "BiocParallel", "_R_CHECK_LIMIT_CORES_", "Bioconductor", "LSF", "PJM", "PBS", "SGE", "Slurm", "fallback", "custom")`)}
+#'  \item{`parallelly.availableCores.methods`:}{(character vector) Default lookup methods for [availableCores()]. (Default: `c("system", "/proc/self/status", "cgroups.cpuset", "cgroups.cpuquota", "cgroups2.cpuset.cpus", "cgroups2.cpuset.cpus.effective", "cgroups2.cpu.max", "nproc", "mc.cores", "BiocParallel", "_R_CHECK_LIMIT_CORES_", "Bioconductor", "HTCondor", "LSF", "PJM", "PBS", "SGE", "Slurm", "fallback", "custom")`)}
 #'
 #'  \item{`parallelly.availableCores.methods.excludes`:}{(character vector) Default lookup methods for [availableCores()] to be excluded. (Default: `NULL`)}
 #'

--- a/inst/testme/test-availableCores.R
+++ b/inst/testme/test-availableCores.R
@@ -73,6 +73,7 @@ stopifnot(length(n) == 1, is.integer(n), n == 1L)
 options(opts)
 
 ## Predefined ones for known cluster schedulers
+print(availableCores(methods = "HTCondor"))
 print(availableCores(methods = "PBS"))
 print(availableCores(methods = "SGE"))
 print(availableCores(methods = "Slurm"))
@@ -89,6 +90,68 @@ stopifnot(inherits(res, "try-error"))
 
 
 ncores0 <- 42L
+
+message("*** HTCondor ...")
+env <- environment(parallelly:::availableCoresHTCondor)
+htcondor_envvars <- c(
+  "_CONDOR_JOB_AD", "_CONDOR_MACHINE_AD", "BATCH_SYSTEM", "OMP_NUM_THREADS"
+)
+old_htcondor_env <- Sys.getenv(htcondor_envvars, unset = NA, names = TRUE)
+job_ad <- tempfile("htcondor-job-ad-")
+machine_ad <- tempfile("htcondor-machine-ad-")
+writeLines(c(
+  "RequestCpus = 2",
+  "CpusProvisioned = 12"
+), job_ad)
+writeLines(c(
+  "Memory = 32768",
+  "Cpus = 18"
+), machine_ad)
+Sys.setenv(
+  `_CONDOR_JOB_AD` = job_ad,
+  `_CONDOR_MACHINE_AD` = machine_ad,
+  BATCH_SYSTEM = "HTCondor",
+  OMP_NUM_THREADS = "24"
+)
+
+## Prefer the provisioned count from the job ClassAd
+env$n <- NULL
+ncores <- availableCores(methods = "HTCondor")
+print(ncores)
+stopifnot(ncores == 12L)
+
+## Fall back to the machine ClassAd
+Sys.unsetenv("_CONDOR_JOB_AD")
+env$n <- NULL
+ncores <- availableCores(methods = "HTCondor")
+print(ncores)
+stopifnot(ncores == 18L)
+
+## Fall back to HTCondor's thread-count environment variable
+Sys.unsetenv("_CONDOR_MACHINE_AD")
+env$n <- NULL
+ncores <- availableCores(methods = "HTCondor")
+print(ncores)
+stopifnot(ncores == 24L)
+
+## Do not treat a user-defined OMP_NUM_THREADS as an HTCondor allocation
+Sys.unsetenv("BATCH_SYSTEM")
+env$n <- NULL
+ncores <- availableCores(
+  methods = "HTCondor", na.rm = FALSE, which = "all"
+)
+print(ncores)
+stopifnot(is.na(ncores))
+
+Sys.unsetenv(htcondor_envvars)
+old_htcondor_env <- old_htcondor_env[!is.na(old_htcondor_env)]
+if (length(old_htcondor_env) > 0L) {
+  do.call(Sys.setenv, as.list(old_htcondor_env))
+}
+unlink(c(job_ad, machine_ad))
+env$n <- NULL
+message("*** HTCondor ... done")
+
 
 message("*** LSF ...")
 message(" - LSB_DJOB_NUMPROC")

--- a/man/availableCores.Rd
+++ b/man/availableCores.Rd
@@ -9,8 +9,8 @@ availableCores(
   methods = getOption2("parallelly.availableCores.methods", c("system",
     "/proc/self/status", "cgroups.cpuset", "cgroups.cpuquota", "cgroups2.cpuset.cpus",
     "cgroups2.cpuset.cpus.effective", "cgroups2.cpu.max", "nproc", "mc.cores",
-    "BiocParallel", "_R_CHECK_LIMIT_CORES_", "Bioconductor", "LSF", "PJM", "PBS", "SGE",
-    "Slurm", "fallback", "custom")),
+    "BiocParallel", "_R_CHECK_LIMIT_CORES_", "Bioconductor", "HTCondor", "LSF", "PJM",
+    "PBS", "SGE", "Slurm", "fallback", "custom")),
   na.rm = TRUE,
   logical = getOption2("parallelly.availableCores.logical", TRUE),
   default = c(current = 1L),
@@ -150,6 +150,14 @@ of 2 cores is considered.
 Query environment variable \env{IS_BIOC_BUILD_MACHINE} (logical)
 used by the Bioconductor (>= 3.16) build and check system. If set to
 true, then a maximum of 4 cores is considered.
+
+\item \code{"HTCondor"} -
+Query CPU resources provisioned by the HTCondor scheduler.
+The number of cores is read from \env{CpusProvisioned} in the job
+ClassAd given by \env{_CONDOR_JOB_AD}, or from \env{Cpus} in the
+machine ClassAd given by \env{_CONDOR_MACHINE_AD}.  If neither
+attribute is available, then \env{OMP_NUM_THREADS} is used when
+\env{BATCH_SYSTEM} identifies an HTCondor job.
 
 \item \code{"LSF"} -
 Query Platform Load Sharing Facility (LSF)/OpenLava environment variable

--- a/man/zzz-parallelly.options.Rd
+++ b/man/zzz-parallelly.options.Rd
@@ -91,7 +91,7 @@ The below \R options and environment variables control the default results of \c
 \describe{
 \item{\code{parallelly.availableCores.logical}:}{(logical) The default value of argument \code{logical} as used by \code{availableCores()}, \code{availableWorkers()}, and \code{availableCores()} for querying \code{parallel::detectCores(logical = logical)}.  The default is \code{TRUE} just like it is for \code{\link[parallel:detectCores]{parallel::detectCores()}}.}
 
-\item{\code{parallelly.availableCores.methods}:}{(character vector) Default lookup methods for \code{\link[=availableCores]{availableCores()}}. (Default: \code{c("system", "/proc/self/status", "cgroups.cpuset", "cgroups.cpuquota", "cgroups2.cpuset.cpus", "cgroups2.cpuset.cpus.effective", "cgroups2.cpu.max", "nproc", "mc.cores", "BiocParallel", "_R_CHECK_LIMIT_CORES_", "Bioconductor", "LSF", "PJM", "PBS", "SGE", "Slurm", "fallback", "custom")})}
+\item{\code{parallelly.availableCores.methods}:}{(character vector) Default lookup methods for \code{\link[=availableCores]{availableCores()}}. (Default: \code{c("system", "/proc/self/status", "cgroups.cpuset", "cgroups.cpuquota", "cgroups2.cpuset.cpus", "cgroups2.cpuset.cpus.effective", "cgroups2.cpu.max", "nproc", "mc.cores", "BiocParallel", "_R_CHECK_LIMIT_CORES_", "Bioconductor", "HTCondor", "LSF", "PJM", "PBS", "SGE", "Slurm", "fallback", "custom")})}
 
 \item{\code{parallelly.availableCores.methods.excludes}:}{(character vector) Default lookup methods for \code{\link[=availableCores]{availableCores()}} to be excluded. (Default: \code{NULL})}
 


### PR DESCRIPTION
## Summary

Add an `HTCondor` method to `availableCores()` and include it in the default lookup sequence.

## Thanks to maintainers

Thanks for keeping this request open and for documenting the scheduler behavior expected by `availableCores()`.

## Issue or motivation

Fixes #50. HTCondor exposes the provisioned CPU count to jobs, but `parallelly` did not query it.

## Root cause

The scheduler dispatch covered LSF, PBS, PJM, SGE, and Slurm, with no HTCondor lookup method.

## Change

The new method reads `CpusProvisioned` from `_CONDOR_JOB_AD`, then `Cpus` from `_CONDOR_MACHINE_AD`. If neither ClassAd value is available, it uses `OMP_NUM_THREADS` when `BATCH_SYSTEM` identifies HTCondor. Documentation and NEWS are updated.

## Tests

- `parallelly:::testme("availableCores")`
- `R CMD check --as-cran --no-manual` — Status: OK

The regression test covers job-ad precedence, machine-ad fallback, the HTCondor environment fallback, and rejection of an unrelated `OMP_NUM_THREADS`.

## Scope

This only adds CPU-count detection to `availableCores()`. It does not add HTCondor host discovery to `availableWorkers()` or change existing scheduler methods.
